### PR TITLE
Add handler to delete /s messages

### DIFF
--- a/server.js
+++ b/server.js
@@ -116,4 +116,21 @@ bot.on(['new_chat_members', 'left_chat_member'], (ctx) => {
   }
 });
 
+/**
+ * Deletes /s messages that people send when they tap on `/s`, when people use
+ * it to denote sarcasm. Sigh.
+ */
+bot.on('message', (ctx) => {
+  if (ctx.message.text) {
+    const message = ctx.message.text;
+    if (message === '/s') {
+      try {
+        ctx.deleteMessage(ctx.message.message_id);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+  }
+});
+
 bot.startPolling();


### PR DESCRIPTION
So someone used `/s` to denote sarcasm
<img width="253" alt="image" src="https://user-images.githubusercontent.com/4933577/90315665-bcbaf180-df4f-11ea-9b61-2b00f9e5f7fd.png">

But people thought it was fun to click on it and after a while it became like this
<img width="220" alt="image" src="https://user-images.githubusercontent.com/4933577/90315677-d3f9df00-df4f-11ea-8c41-ff9b8d54a005.png">

Yeap. Sigh. Merge this if you think it's useful lmao.